### PR TITLE
Fix windows resource target in CMake

### DIFF
--- a/ramses-citymodel-demo/CMakeLists.txt
+++ b/ramses-citymodel-demo/CMakeLists.txt
@@ -27,6 +27,7 @@ MACRO(INSTALL_RESOURCES files)
    
    set(targetName copy-files-${CMAKE_CURRENT_SOURCE_DIR})
    string(REPLACE "/" "-" targetName ${targetName})
+   string(REPLACE ":" "-" targetName ${targetName})
    add_custom_target(${targetName} ALL DEPENDS ${targetFiles})
    
    install(FILES ${targetFiles} DESTINATION bin/res)


### PR DESCRIPTION
Windows has ":" in the paths, and CMake doesn't like that, same as "\" and "/". Apply the same fix as for
Unix paths.